### PR TITLE
🐦 🐦 🐦 🗿

### DIFF
--- a/config/svg.php
+++ b/config/svg.php
@@ -1,6 +1,6 @@
 <?php
 
-use function Roots\public_path;
+use function Roots\base_path;
 
 return [
 
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'path' => public_path(),
+    'path' => base_path('dist'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/SageSvgServiceProvider.php
+++ b/src/SageSvgServiceProvider.php
@@ -18,7 +18,7 @@ class SageSvgServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(Svg::class, function () {
+        $this->app->singleton(SvgSvg::class, function () {
             return new SageSvg($this->config());
         });
     }

--- a/src/SageSvgServiceProvider.php
+++ b/src/SageSvgServiceProvider.php
@@ -18,7 +18,7 @@ class SageSvgServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(SvgSvg::class, function () {
+        $this->app->singleton(SageSvg::class, function () {
             return new SageSvg($this->config());
         });
     }

--- a/src/SageSvgServiceProvider.php
+++ b/src/SageSvgServiceProvider.php
@@ -6,7 +6,7 @@ use Roots\Acorn\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
 
 use function Roots\config;
-use function Roots\public_path;
+use function Roots\base_path;
 use function Roots\config_path;
 
 class SageSvgServiceProvider extends ServiceProvider
@@ -43,9 +43,9 @@ class SageSvgServiceProvider extends ServiceProvider
      */
     protected function config()
     {
-        return collect(config('svg', []))->merge([
-            'path' => public_path(),
-        ])->all();
+        return collect(['path' => base_path('dist')])
+            ->merge(config('svg', []))
+            ->all();
     }
 
     /**


### PR DESCRIPTION
Killing a few birds with one stone in this PR:

* Corrects singleton abstract name from (`Svg` to `SageSvg`)
  * Previously, this was causing the user config not be loaded and the default to be used.
* Corrects config loading order
  * Previously, the default config would be applied over anything that the developer set.
* Use `base_path('dist')` instead of `public_path()` since the latter resolves to `'public'` in the theme directory and Sage 10 doesn't use that by default. This can change back in the future once changes are made in Acorn.

Sorry for longest PR branch name in existence.