### PR TITLE
fix(provider): check for blade before binding directives

### DIFF
--- a/src/SageSvgServiceProvider.php
+++ b/src/SageSvgServiceProvider.php
@@ -26,7 +26,9 @@ class SageSvgServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->directives();
+        if ($this->app->bound('blade.compiler')) {
+            $this->directives();
+        }
         $this->publishes([
             __DIR__ . '/../config/svg.php' => $this->app->configPath('svg.php')
         ]);


### PR DESCRIPTION
If Blade isn't bound, then end users will see "Fatal error: Uncaught ReflectionException: Class blade.compiler does not exist"

This resolves that error.