### PR TITLE
Fix variable type mismatch

### DIFF
--- a/src/SageSvgServiceProvider.php
+++ b/src/SageSvgServiceProvider.php
@@ -77,7 +77,7 @@ class SageSvgServiceProvider extends ServiceProvider
             return;
         }
 
-        if ($directives = collect($this->app->config->get('svg.directives'))->isEmpty()) {
+        if (($directives = collect($this->app->config->get('svg.directives')))->isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
```
Error thrown with message "Call to a member function each() on bool"

Stacktrace:
#19 Error in /opt/project/web/app/themes/--/vendor/log1x/sage-svg/src/SageSvgServiceProvider.php:84
```