### PR TITLE
Remove deprecated Roots\public_path()

### DIFF
--- a/config/svg.php
+++ b/config/svg.php
@@ -1,7 +1,5 @@
 <?php
 
-use function Roots\public_path;
-
 return [
 
     /*
@@ -13,9 +11,11 @@ return [
     | This path is then resolved internally if an absolute path is not being
     | used.
     |
+    | Example: Icons are in web/app/themes/theme_name/resources/images/icons/
+    | Base Path: base_path('resources/images/icons'),
     */
 
-    'path' => public_path(),
+    'path' => base_path(),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/svg.php
+++ b/config/svg.php
@@ -11,11 +11,9 @@ return [
     | This path is then resolved internally if an absolute path is not being
     | used.
     |
-    | Example: Icons are in web/app/themes/theme_name/resources/images/icons/
-    | Base Path: base_path('resources/images/icons'),
     */
 
-    'path' => base_path(),
+    'path' => public_path(),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Also included helpful flavor-text, as it took me a minute to "get it working" properly, because one of the online flavor help-notes I found said to use `public/images/icons/` instead! :D 

Vaguely related to #11, but not sure there's an issue for the deprecation.

![image](https://user-images.githubusercontent.com/1015474/231181531-249feb9b-c3c7-498f-916d-89fcfd5f0dc0.png)

![image](https://user-images.githubusercontent.com/1015474/231181894-7db3af43-2cdb-4317-839f-ad1f1bbe3b12.png)


