### PR TITLE
Add optional parameter to prefix all IDs within SVG to avoid clashes

### DIFF
--- a/src/SageSvg.php
+++ b/src/SageSvg.php
@@ -75,7 +75,7 @@ class SageSvg
         if ($options->get('idPrefix')) {
             $svg = preg_replace(
                 '/(id=[\'"]|url\([\'"]?#|href=["\']#)(.*?)([\'"])/m',
-                '$1$2$3',
+                "$1{$options->get('idPrefix')}-$2$3",
                 $svg
             );
         }

--- a/src/SageSvg.php
+++ b/src/SageSvg.php
@@ -47,9 +47,10 @@ class SageSvg
      * @param  string       $image
      * @param  string|array $class
      * @param  array        $attrs
+     * @param  string       $id_prefix
      * @return \Illuminate\Support\HtmlString
      */
-    public function render($image, $class = '', $attrs = [])
+    public function render($image, $class = '', $attrs = [], $id_prefix = '')
     {
         if (is_array($class)) {
             $class = implode(' ', $class);
@@ -59,15 +60,20 @@ class SageSvg
             'class' => $this->buildClass($class)
         ])->filter()->all();
 
-        return new HtmlString(
-            str_replace(
-                '<svg',
-                sprintf('<svg%s', $this->buildAttributes($attrs)),
-                $this->get(
-                    $this->prepare($image)
-                )
+        $html = str_replace(
+            '<svg',
+            sprintf('<svg%s', $this->buildAttributes($attrs)),
+            $this->get(
+                $this->prepare($image)
             )
         );
+
+        if($id_prefix != '') {
+            $re = '/(id=[\'"]|url\([\'"]?#|href=["\']#)(.*?)([\'"])/m';
+            $html = preg_replace($re, '$1$2$3', $html);
+        }
+
+        return new HtmlString($html);
     }
 
     /**

--- a/src/SageSvg.php
+++ b/src/SageSvg.php
@@ -47,11 +47,15 @@ class SageSvg
      * @param  string       $image
      * @param  string|array $class
      * @param  array        $attrs
-     * @param  string       $id_prefix
+     * @param  array        $options
      * @return \Illuminate\Support\HtmlString
      */
-    public function render($image, $class = '', $attrs = [], $id_prefix = '')
+    public function render($image, $class = '', $attrs = [], $options = [])
     {
+        $options = collect([
+            'idPrefix' => null,
+        ])->merge($options);
+
         if (is_array($class)) {
             $class = implode(' ', $class);
         }
@@ -60,7 +64,7 @@ class SageSvg
             'class' => $this->buildClass($class)
         ])->filter()->all();
 
-        $html = str_replace(
+        $svg = str_replace(
             '<svg',
             sprintf('<svg%s', $this->buildAttributes($attrs)),
             $this->get(
@@ -68,12 +72,15 @@ class SageSvg
             )
         );
 
-        if($id_prefix != '') {
-            $re = '/(id=[\'"]|url\([\'"]?#|href=["\']#)(.*?)([\'"])/m';
-            $html = preg_replace($re, '$1$2$3', $html);
+        if ($options->get('idPrefix')) {
+            $svg = preg_replace(
+                '/(id=[\'"]|url\([\'"]?#|href=["\']#)(.*?)([\'"])/m',
+                '$1$2$3',
+                $svg
+            );
         }
 
-        return new HtmlString($html);
+        return new HtmlString($svg);
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,12 +14,13 @@ use function Roots\app;
  * @param  string       $image
  * @param  string|array $class
  * @param  array        $attrs
+ * @param  array        $options
  * @return string
  */
 
 if (! function_exists('get_svg')) {
-    function get_svg($image, $class = '', $attrs = [], $id_prefix = '')
+    function get_svg($image, $class = '', $attrs = [], $options = [])
     {
-        return app(SageSvg::class)->render($image, $class, $attrs, $id_prefix);
+        return app(SageSvg::class)->render($image, $class, $attrs, $options);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -18,8 +18,8 @@ use function Roots\app;
  */
 
 if (! function_exists('get_svg')) {
-    function get_svg($image, $class = '', $attrs = [])
+    function get_svg($image, $class = '', $attrs = [], $id_prefix = '')
     {
-        return app(SageSvg::class)->render($image, $class, $attrs);
+        return app(SageSvg::class)->render($image, $class, $attrs, $id_prefix);
     }
 }


### PR DESCRIPTION
### Purpose
Provide a way to prevent clashes between IDs used in SVGs.

### The problem it solves
When an SVG is used more than once on a page, any IDs used within in the SVG will not be unique. This can cause problems when an SVG is relying on an ID (eg. for a `clip-path` or `linear-gradient`), as it can be referencing the wrong one. (Particularly a problem when you're animating SVGs!)

ID clashes often occur across multiple SVGs too, particularly when the IDs used are vague (eg. `id="gradient1"`) or have been exported from another tool (eg. `id="Layer1"`).

### The solution
I've added another parameter to the `@svg` directive called `$id_prefix`. It allows the developer to provide a string that will be prefixed to all the IDs used within the SVG.

### Usage and example
You may be using the same logo in the header and footer of the site. If the logo relies on an ID (eg. for a linear-gradient), there will be an ID clash. To get around this, you'd just pass different prefixes to the directive. 

``` php
@svg('images.logo', 'w-32', ['aria-label' => 'Logo'], 'header-logo')
```

### A detailed example

Without providing an ID prefix, my SVG markup looks like this. (This SVG was exported from Illustrator, and run manually through [SVGOMG](https://jakearchibald.github.io/svgomg/) which simplified the ID to just `a` – optimised, but not super helpful...

``` html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
  <defs>
    <linearGradient id="a" x1="0" x2="100" y1="50" y2="50" gradientUnits="userSpaceOnUse">
      <stop offset="0" stop-color="#b6ff2a" />
      <stop offset=".995" stop-color="#0097ff" />
    </linearGradient>
  </defs>
  <path fill="url(#a)"
    d="M50 0C22.386 0 0 22.386 0 50s22.386 50 50 50 50-22.386 50-50S77.614 0 50 0Zm0 92.148C26.722 92.148 7.852 73.278 7.852 50S26.722 7.852 50 7.852 92.148 26.722 92.148 50 73.278 92.148 50 92.148Z"/>
</svg>
```

``` php
@svg('images.logo', 'w-32', ['aria-label' => 'Logo'], 'header-logo')
```

Passing an $id_prefix parameter to the `@svg` directive turns my SVG's unhelpful ID of `a` into the more specific `header-logo-a`, both where it's declared on the `linearGradient` in `defs` and where it's referenced as the `fill` on the `path`.

``` html
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
  <defs>
    <linearGradient id="header-logo-a" x1="0" x2="100" y1="50" y2="50" gradientUnits="userSpaceOnUse">
      <stop offset="0" stop-color="#b6ff2a" />
      <stop offset=".995" stop-color="#0097ff" />
    </linearGradient>
  </defs>
  <path fill="url(#header-logo-a)"
    d="M50 0C22.386 0 0 22.386 0 50s22.386 50 50 50 50-22.386 50-50S77.614 0 50 0Zm0 92.148C26.722 92.148 7.852 73.278 7.852 50S26.722 7.852 50 7.852 92.148 26.722 92.148 50 73.278 92.148 50 92.148Z"/>
</svg>
```

### tldr;
With the addition of an `$id_prefix` parameter to the `@svg` directive, the developer is back in control of how unique an SVG's IDs are, even if that SVG is stored in the CMS. 