### PR TITLE
Add support for multiple manifests and child theme

### DIFF
--- a/src/SageSvg.php
+++ b/src/SageSvg.php
@@ -78,11 +78,12 @@ class SageSvg
      */
     protected function get($image)
     {
-        $manifests = app('config')->get('assets.manifests');
-        foreach ($manifests as $manifest_key => $manifest) {
-            if (asset($image, $manifest_key)->exists()) {
+        $manifests = config('assets.manifests');
+
+        foreach ($manifests as $key => $value) {
+            if (asset($image, $key)->exists()) {
                 return trim(
-                    asset($image, $manifest_key)->contents()
+                    asset($image, $key)->contents()
                 );
             }
         }

--- a/src/SageSvg.php
+++ b/src/SageSvg.php
@@ -78,10 +78,13 @@ class SageSvg
      */
     protected function get($image)
     {
-        if (asset($image)->exists()) {
-            return trim(
-                asset($image)->contents()
-            );
+        $manifests = app('config')->get('assets.manifests');
+        foreach ($manifests as $manifest_key => $manifest) {
+            if (asset($image, $manifest_key)->exists()) {
+                return trim(
+                    asset($image, $manifest_key)->contents()
+                );
+            }
         }
 
         if ($this->files->exists($image)) {


### PR DESCRIPTION
Hey, 
I am using multiple manifests to distinct between parent and child theme, like this:
```
    'manifests' => [
        // For child theme
        'child' => [
            'path' => get_theme_file_path('public'),
            'url' => get_theme_file_uri('public'),
            'assets' => get_theme_file_path('public/manifest.json'),
            'bundles' => get_theme_file_path('public/entrypoints.json'),
        ],
        // For parent theme
        'parent' => [
            'path' => get_parent_theme_file_path('public'),
            'url' => get_parent_theme_file_uri('public'),
            'assets' => get_parent_theme_file_path('public/manifest.json'),
            'bundles' => get_parent_theme_file_path('public/entrypoints.json'),
        ],
    ],
 ```
Basically, in child theme, I am firstly looking for assets in the child theme and then fallback to parent theme.
SVGs are not working this way because `asset()` function  only looks for the single manifest and ignores other ones. 

This PR brings compatibility with multiple defined manifests and checks each of them.

Can you please check if it makes sense to you?
Thanks