### PR TITLE
Fix null value deprecation error for `Str::endsWith`

### DIFF
--- a/src/SageSvg.php
+++ b/src/SageSvg.php
@@ -93,7 +93,7 @@ class SageSvg
         foreach ($this->manifests as $key => $value) {
             $bundle = $value['bundles'] ?? null;
 
-            if (Str::endsWith($bundle, 'build/manifest.json')) {
+            if ($bundle && Str::endsWith($bundle, 'build/manifest.json')) {
                 try {
                     return Vite::content(Str::of($image)->ltrim('/')->start('resources/')->__toString());
                 } catch (Throwable) {


### PR DESCRIPTION
This is almost nothing but is hitting me hard right now.
When the bundle values are missing (which can happen for different reasons), then the local value gets `null` which is not accepted as an argument for `Str::endsWith()`.

```
ErrorException: Deprecated: str_ends_with(): Passing null to parameter #1 ($haystack) of type string is deprecated
#44 root/vendor/illuminate/support/Str.php(322): Illuminate\Support\Str::endsWith
#43 root/vendor/log1x/sage-svg/src/SageSvg.php(96): Log1x\SageSvg\SageSvg::asset
#42 root/vendor/log1x/sage-svg/src/SageSvg.php(69): Log1x\SageSvg\SageSvg::getContents
#41 root/vendor/log1x/sage-svg/src/SageSvg.php(49): Log1x\SageSvg\SageSvg::render
#40 root/vendor/log1x/sage-svg/src/helpers.php(16): get_svg
#39 root/web/app/themes/theme/storage/framework/views/246666fbe147d06bbcf009f62287874f.php(8): require
```